### PR TITLE
Fix smart quotes in email subject (and other chars)

### DIFF
--- a/welcome-pack.php
+++ b/welcome-pack.php
@@ -798,7 +798,7 @@ To view the original activity, your comment and all replies, log in and visit: %
 
 			$email        = array_shift( $email );
 			$post_content = apply_filters( 'the_content', $email->post_content );
-			$post_title   = apply_filters( 'the_title', $email->post_title, $email->ID );
+			$post_title   = apply_filters( 'dpw_email_subject', $email->post_title, $email->ID );
 
 			$bp->welcome_pack->$subject->message  = $post_content;
 			$bp->welcome_pack->$subject->subject  = $post_title;


### PR DESCRIPTION
Applying the_title filter uses wptexturize(), which introduces a number of characters that don't display reliably in email subject lines. For instance: You have an invitation to the group: &#8220;Group Name&#8221;
