### PR TITLE
Make sure the functions are called statically

### DIFF
--- a/welcome-pack.php
+++ b/welcome-pack.php
@@ -141,7 +141,7 @@ class DP_Welcome_Pack {
 	 *
 	 * @since 3.0
 	 */
-	public function check_installed() {
+	public static function check_installed() {
 		global $bp;
 
 		// Only run this for super admins, so our emails aren't inserted into the database by a non-admin.
@@ -248,7 +248,7 @@ class DP_Welcome_Pack {
 	 *
 	 * @since 3.0
 	 */
-	public function setup_admin() {
+	public static function setup_admin() {
 		require( dirname( __FILE__ ) . '/welcome-pack-admin.php' );
 		new DP_Welcome_Pack_Admin();
 


### PR DESCRIPTION
Hey @paulgibbs,

We're using Welcome Pack on a client project at the moment using php 5.4 and the following warnings are thrown:

```
Strict Standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method DP_Welcome_Pack::setup_admin() should not be called statically in /vagrant/wp/wp-includes/plugin.php on line 470

Strict Standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method DP_Welcome_Pack::check_installed() should not be called statically in /vagrant/wp/wp-includes/plugin.php on line 470
```

I've attached the easiest PR I've ever had to do ever :smile:

Thanks for making Welcome Pack :+1: 
