### PR TITLE
Fix Dashboard notices

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=P3K7Z
 Tags: buddypress,friend,group,welcome,message,email,customise,customize,initial,redirect,registration,start
 Requires at least: WordPress 3.2, BuddyPress 1.5.1
 Tested up to: WP 3.3.1, BuddyPress 1.5.3.1
-Stable tag: 3.3
+Stable tag: 3.3.1
 
 Automatically send friend/group invites and a welcome message to new users, and redirect them to a custom page. Also provides email customisation options.
 
@@ -34,6 +34,9 @@ Fixes error handling when something goes wrong sending a welcome message.
 Updated for BuddyPress 1.5 and WordPress 3.2. Revamped email customisations options and admin area. Contains 47% more awesome.
 
 == Changelog ==
+
+= 3.3.1 =
+Fixes Strict notices on PHP 5.4 when WP_DEBUG is enabled.
 
 = 3.3 =
 Fix; only customises the emails when you've enabled that option.

--- a/welcome-pack-admin.php
+++ b/welcome-pack-admin.php
@@ -34,7 +34,7 @@ class DP_Welcome_Pack_Admin {
 	 *
 	 * @since 3.0
 	 */
-	public function setup_menu() {
+	public static function setup_menu() {
 		if ( !is_admin() || ( !is_user_logged_in() || !is_super_admin() ) )
 			return;
 
@@ -803,7 +803,7 @@ class DP_Welcome_Pack_Admin {
 	 * @return string
 	 * @since 3.0
 	 */
-	public function email_subject_placeholder( $title ) {
+	public static function email_subject_placeholder( $title ) {
 		$screen = get_current_screen();
 
 		if ( 'dpw_email' == $screen->post_type )
@@ -819,7 +819,7 @@ class DP_Welcome_Pack_Admin {
 	 * @param WP_Post $post
 	 * @since 3.0
 	 */
-	public function email_maybe_save( $post_ID, $post ) {
+	public static function email_maybe_save( $post_ID, $post ) {
 		// Check this is an email
 		if ( 'dpw_email' != $post->post_type )
 			return;

--- a/welcome-pack.php
+++ b/welcome-pack.php
@@ -3,7 +3,7 @@
  * Plugin Name: Welcome Pack
  * Plugin URI: http://buddypress.org/community/groups/welcome-pack/
  * Description: Automatically send friend/group invites and a welcome message to new users, and redirect them to a custom page. Also provides email customisation options.
- * Version: 3.3
+ * Version: 3.3.1
  * Requires at least: WordPress 3.2, BuddyPress 1.5.1
  * Tested up to: WP 3.3.1, BuddyPress 1.5.3.1
  * License: GPL3


### PR DESCRIPTION
Hey again @paulgibbs,

Thanks for the speedy merge of my other PR :smile:! I was working on frontend stuff for most of today and only just realised there are a few notices in the admin as well.

```
Strict Standards:  call_user_func_array() expects parameter 1 to be a valid callback, non-static method DP_Welcome_Pack_Admin::setup_menu() should not be called statically in /vagrant/wp/wp-includes/plugin.php on line 470

Strict Standards:  call_user_func_array() expects parameter 1 to be a valid callback, non-static method DP_Welcome_Pack_Admin::email_maybe_save() should not be called statically in /vagrant/wp/wp-includes/plugin.php on line 470

Strict Standards:  call_user_func_array() expects parameter 1 to be a valid callback, non-static method DP_Welcome_Pack_Admin::email_subject_placeholder() should not be called statically in /vagrant/wp/wp-includes/plugin.php on line 192
```

I've attached a PR to resolve those as well and have suggested a minor version bump but I'm happy to revert that if you don't want to bump it!

Thanks again!
